### PR TITLE
Add compile-time checks for interface compliance.

### DIFF
--- a/set_nots.go
+++ b/set_nots.go
@@ -22,6 +22,9 @@ func NewNonTS(items ...interface{}) *SetNonTS {
 	s := &SetNonTS{}
 	s.m = make(map[interface{}]struct{})
 
+	// Ensure interface compliance
+	var _ Interface = s
+
 	s.Add(items...)
 	return s
 }

--- a/set_ts.go
+++ b/set_ts.go
@@ -17,6 +17,9 @@ func New(items ...interface{}) *Set {
 	s := &Set{}
 	s.m = make(map[interface{}]struct{})
 
+	// Ensure interface compliance
+	var _ Interface = s
+
 	s.Add(items...)
 	return s
 }


### PR DESCRIPTION
this is a little trick i picked up...can't remember where, somewhere on the go-nuts mailing list. it's just a nice way of ensuring that code won't even compile unless the structs correctly implement the interface.
